### PR TITLE
docs: update bytecode examples and documentation for clarity

### DIFF
--- a/reference/bytecode.md
+++ b/reference/bytecode.md
@@ -2,6 +2,8 @@
 
 The Ovum Intermediate Language (Ovum bytecode) is a stack-based virtual machine instruction set that serves as the compilation target for Ovum source code. This document describes the bytecode syntax, structure, and available commands.
 
+See also: [bytecode command list](./bytecode_commands.md) and [bytecode examples](./bytecode_examples.md).
+
 ## General Syntax
 
 Ovum bytecode follows a stack-based execution model where operations consume values from the stack and push results back onto the stack. The syntax uses WASM-like code blocks enclosed in curly braces `{}`.

--- a/reference/bytecode_examples.md
+++ b/reference/bytecode_examples.md
@@ -228,9 +228,13 @@ function _Global_Main_StringArray {
     PushInt 3
     PushInt 4
     CallConstructor Point
-    
-    Call _Point_GetDistance_<C> // Cll regular methods
+    SetLocal 0
+    LoadLocal 0
+    Call _Point_GetDistance_<C> // Call regular methods
     Call _Float_ToString_<C>
+    PrintLine
+    LoadLocal 0
+    Call Point_ToString_<C>
     PrintLine
     
     PushInt 0

--- a/reference/lexical_structure.md
+++ b/reference/lexical_structure.md
@@ -23,7 +23,7 @@ Ovum reserves certain words like `fun`, `class`, `interface`, `var`, `override`,
 
 * **Arithmetic**: `+`, `-`, `*`, `/`, `%`
 * **Comparison**: `==`, `!=`, `<`, `<=`, `>`, `>=`
-* **Boolean logic**: `&&` (logical AND), `||` (logical OR), `!` (negation), `xor` (exclusive OR)
+* **Boolean logic**: `&&` (logical AND), `||` (logical OR), `!` (negation), `^` (exclusive OR)
 * **Assignment**: `=` (reference assignment), `:=` (copy assignment)
 * **Null handling**: `?.` (safe call), `?:` (Elvis)
 * **Type operations**: `as` (cast), `is` (type test)
@@ -116,7 +116,7 @@ ElvisExpr       ::= OrExpr [ "?:" ElvisExpr ] ;  // right-assoc
 
 OrExpr          ::= AndExpr { "||" AndExpr } ;
 AndExpr         ::= XorExpr { "&&" XorExpr } ;
-XorExpr         ::= EqualityExpr { "xor" EqualityExpr } ;
+XorExpr         ::= EqualityExpr { "^" EqualityExpr } ;
 
 EqualityExpr    ::= RelExpr { ("==" | "!=") RelExpr } ;
 RelExpr         ::= AddExpr { ("<" | "<=" | ">" | ">=") AddExpr } ;


### PR DESCRIPTION
This commit enhances the bytecode examples by adding local variable usage and improving method calls for better clarity. Additionally, it updates the bytecode documentation to include a reference to the bytecode command list and examples, ensuring a more comprehensive understanding of the Ovum bytecode structure.