### PR TITLE
Update bytecode documentation with static variable handling and…

### DIFF
--- a/reference/bytecode.md
+++ b/reference/bytecode.md
@@ -70,6 +70,22 @@ While loops consist of separate condition blocks and execution blocks connected 
 }
 ```
 
+#### Init-Static Block
+
+The `init-static` block is a unique block that must appear exactly once in a bytecode file. It contains initialization code that is executed before the `Main` function is called, primarily for setting up static variables:
+
+```oil
+// Static initialization block (must be unique, executed before Main)
+init-static {
+    PushInt 42
+    SetStatic 0  // Set static variable at index 0
+    PushString "Initialized"
+    SetStatic 1  // Set static variable at index 1
+    PushFloat 3.14
+    SetStatic 2  // Set static variable at index 2
+}
+```
+
 #### Functions
 
 Functions are defined with optional keywords and contain a sequence of bytecode instructions:

--- a/reference/bytecode_commands.md
+++ b/reference/bytecode_commands.md
@@ -20,8 +20,8 @@ All commands expect arguments of proper size on the stack and push return value 
 
 * `LoadLocal <index>` - Loads a local variable onto the stack
 * `SetLocal <index>` - Stores the top stack value to a local variable
-* `LoadStatic <name>` - Loads a static variable onto the stack
-* `SetStatic <name>` - Stores the top stack value to a static variable
+* `LoadStatic <index>` - Loads a static variable onto the stack
+* `SetStatic <index>` - Stores the top stack value to a static variable
 
 ## Array Operations
 

--- a/reference/bytecode_examples.md
+++ b/reference/bytecode_examples.md
@@ -299,10 +299,15 @@ fun Main(args: StringArray): Int {
 }
 ```
 
-## Interface-Based Polymorphism
+## Interface-Based Polymorphism and Static Variables
 
 **OIL Bytecode Target:**
 ```oil
+init-static {
+    PushFloat 3.14159
+    SetStatic 0
+}
+
 // Rectangle VTable definition
 vtable Rectangle {
     size: 24 // 4 bytes (vtable index) + 4 bytes (badge) + 2 * Ref (8 bytes each)
@@ -386,14 +391,14 @@ function:2 _Circle_Constructor_<M>_float {
 
 // Circle interface method: GetArea
 function:1 _Circle_GetArea_<C> {
-    LoadLocal 0  // this pointer
-    GetField 0
-    Unwrap
+    LoadStatic 0  // PI
     LoadLocal 0  // this pointer
     GetField 0
     Unwrap
     FloatMultiply
-    PushFloat 3.14159
+    LoadLocal 0  // this pointer
+    GetField 0
+    Unwrap
     FloatMultiply
     CallConstructor _Float_float
     Return
@@ -401,12 +406,12 @@ function:1 _Circle_GetArea_<C> {
 
 // Circle interface method: GetPerimeter
 function:1 _Circle_GetPerimeter_<C> {
+    PushFloat 2.0
+    LoadStatic 0  // PI
+    FloatMultiply
     LoadLocal 0  // this pointer
     GetField 0
     Unwrap
-    PushFloat 2.0
-    FloatMultiply
-    PushFloat 3.14159
     FloatMultiply
     CallConstructor _Float_float
     Return
@@ -460,6 +465,8 @@ function:1 _Global_Main_StringArray {
 
 **Ovum Source Code:**
 ```ovum
+static val PI: Float = 3.14159
+
 interface IShape {
     fun GetArea(): Float
     fun GetPerimeter(): Float
@@ -493,11 +500,11 @@ class Circle implements IShape {
     }
     
     public override fun GetArea(): Float {
-        return 3.14159 * Radius * Radius
+        return PI * Radius * Radius
     }
     
     public override fun GetPerimeter(): Float {
-        return 2.0 * 3.14159 * Radius
+        return 2.0 * PI * Radius
     }
 }
 

--- a/reference/syntax.md
+++ b/reference/syntax.md
@@ -5,7 +5,7 @@
 * Declared with `fun`, PascalCase names: `fun Compute(a: Int): Int { ... }`
 * **Pure** functions: `pure fun Hash(o: Object): Int { ... }`
   * Side-effect free; VM may cache results.
-  * If parameters include user-defined reference types, those types must implement **`IComparable`**.
+  * If parameters include user-defined reference types, those types must implement **`IHashable`**.
 
 ## Classes
 


### PR DESCRIPTION
… initialization

This commit enhances the bytecode documentation by introducing the `init-static` block for initializing static variables before the `Main` function. It also updates the `LoadStatic` and `SetStatic` command descriptions to reflect the use of indices instead of names. Additionally, examples are modified to demonstrate the use of static variables in the context of interface-based polymorphism, improving clarity and understanding of static variable management in the Ovum bytecode.