### PR TITLE
Update bytecode documentation with new PushByte command

### DIFF
--- a/reference/bytecode.md
+++ b/reference/bytecode.md
@@ -111,8 +111,8 @@ pure(int, int) function:2 _Global_IsEven_int_int {
 }
 
 // Pure function with mixed argument types
-// Arguments: Obj (String), int (int)
-pure(Obj, int) function:2 _Global_StringRepeat_String_int {
+// Arguments: String, int
+pure(String, int) function:2 _Global_StringRepeat_String_int {
     LoadLocal 0  // String reference
     LoadLocal 1  // Int copy
     Call _Global_StringRepeatImpl_String_int
@@ -159,8 +159,8 @@ vtable <ClassName> {
         ...
     }
     vartable {
-        <fieldName>: <typename>@<offset>
-        <fieldName>: <typename>@<offset>
+        <fieldName>: <typename|Object>@<offset> // typename for fundamental types, Object for user-defined types
+        <fieldName>: <typename|Object>@<offset> // typename for fundamental types, Object for user-defined types
         ...
     }
 }

--- a/reference/bytecode_commands.md
+++ b/reference/bytecode_commands.md
@@ -9,6 +9,7 @@ All commands expect arguments of proper size on the stack and push return value 
 * `PushFloat <value>` - Pushes a 64-bit floating-point literal onto the stack
 * `PushBool <value>` - Pushes a Boolean literal (`true` or `false`) onto the stack
 * `PushChar <value>` - Pushes a character literal onto the stack
+* `PushByte <value>` - Pushes a byte literal onto the stack
 * `PushString <value>` - Pushes a string literal onto the stack
 * `PushNull` - Pushes `null` into a nullable wrapper onto the stack
 * `Pop` - Removes the top value from the stack

--- a/reference/bytecode_examples.md
+++ b/reference/bytecode_examples.md
@@ -310,7 +310,7 @@ init-static {
 
 // Rectangle VTable definition
 vtable Rectangle {
-    size: 24 // 4 bytes (vtable index) + 4 bytes (badge) + 2 * Ref (8 bytes each)
+    size: 24 // 4 bytes (vtable index) + 4 bytes (badge) + 2 * Object (8 bytes each)
     interfaces {
         IShape
     }
@@ -319,14 +319,14 @@ vtable Rectangle {
         _Rectangle_GetPerimeter_<C>: _Rectangle_GetPerimeter_<C>
     }
     vartable {
-        Width: Float@8
-        Height: Float@16
+        Width: Object@8
+        Height: Object@16
     }
 }
 
 // Circle VTable definition
 vtable Circle {
-    size: 16 // 4 bytes (vtable index) + 4 bytes (badge) + 1 * Ref (8 bytes)
+    size: 16 // 4 bytes (vtable index) + 4 bytes (badge) + 1 * Object (8 bytes)
     interfaces {
         IShape
     }
@@ -335,7 +335,7 @@ vtable Circle {
         _Circle_GetPerimeter_<C>: _Circle_GetPerimeter_<C>
     }
     vartable {
-        Radius: Float@8
+        Radius: Object@8
     }
 }
 


### PR DESCRIPTION
This commit adds the `PushByte` command to the bytecode commands documentation, enhancing the command list. Additionally, it clarifies the use of `Object` types in the vtable definitions and variable tables within the bytecode examples, ensuring consistency and improving understanding of type handling in the Ovum bytecode.